### PR TITLE
ci: Fix docs generation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,7 +2,7 @@ name: Generate & Deploy Documentation
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   generate-and-deploy:


### PR DESCRIPTION
GitHub no longer calls the default branch 'master' but 'main'. The
workflow file I reused was taken from a project that started before this
change took place.