### PR TITLE
style: Start signal names with "on"

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -74,9 +74,10 @@ void MainWindow::setupActions()
 
     // MQTT related signals
     connect(this->ui->actionConnect, &QAction::triggered, mqtt_manager, &MQTTManager::connect);
-    connect(this->mqtt_manager, &MQTTManager::connectedChanged, this, &MainWindow::updateStatusBar);
-    connect(this->mqtt_manager, &MQTTManager::messageReceived, this, &MainWindow::messageReceived);
     connect(this->ui->actionNewConnection, &QAction::triggered, this, &MainWindow::OpenConnectionWindow);
+    connect(this->mqtt_manager, &MQTTManager::onConnected, this, &MainWindow::updateStatusBar);
+    connect(this->mqtt_manager, &MQTTManager::onDisconnected, this, &MainWindow::updateStatusBar);
+    connect(this->mqtt_manager, &MQTTManager::onMessageReceived, this, &MainWindow::messageReceived);
 }
 
 void MainWindow::updateStatusBar()

--- a/src/mqttmanager.cpp
+++ b/src/mqttmanager.cpp
@@ -17,34 +17,34 @@ public:
 
     void on_success(const mqtt::token& tok) override
     {
-        emit this->mqtt_manager->operationSucceeded(tok);
+        emit this->mqtt_manager->onOperationSucceeded(tok);
     }
 
     void on_failure(const mqtt::token& tok) override
     {
-        emit this->mqtt_manager->operationFailed(tok);
+        emit this->mqtt_manager->onOperationFailed(tok);
     }
 
     void connected(const std::string& cause) override
     {
         this->mqtt_manager->connected = true;
-        emit this->mqtt_manager->connectedChanged(true);
+        emit this->mqtt_manager->onConnected();
     }
 
     void connection_lost(const std::string& cause) override
     {
         this->mqtt_manager->connected = false;
-        emit this->mqtt_manager->connectedChanged(false);
+        emit this->mqtt_manager->onDisconnected();
     }
 
     void message_arrived(mqtt::const_message_ptr msg) override
     {
-        emit this->mqtt_manager->messageReceived(msg);
+        emit this->mqtt_manager->onMessageReceived(msg);
     }
 
     void delivery_complete(mqtt::delivery_token_ptr tok) override
     {
-        emit this->mqtt_manager->messageDelivered(tok);
+        emit this->mqtt_manager->onMessageDelivered(tok);
     }
 
 private:

--- a/src/mqttmanager.h
+++ b/src/mqttmanager.h
@@ -29,33 +29,36 @@ public slots:
 
 signals:
     /**
-     * @brief connectedChanged is emitted when the connection status of the
-     * client changes
-     * @param connected whether client is connected or not
+     * @brief onConnected is emitted when the client connects to a server
      */
-    void connectedChanged(bool connected);
+    void onConnected();
     /**
-     * @brief messageReceived is emitted when a message arrives from the server
+     * @brief onDisconnected is emitted when the client disconnects from a
+     * server
+     */
+    void onDisconnected();
+    /**
+     * @brief onMessageReceived is emitted when a message arrives from the server
      * @param msg See mqtt::message
      */
-    void messageReceived(const mqtt::const_message_ptr msg);
+    void onMessageReceived(const mqtt::const_message_ptr msg);
     /**
-     * @brief messageDelivered is emitted when delivery for a message has been
+     * @brief onMessageDelivered is emitted when delivery for a message has been
      * completed, and all acknowledgments have been received
      * @param tok See mqtt::delivery_token
      */
-    void messageDelivered(mqtt::delivery_token_ptr tok);
+    void onMessageDelivered(mqtt::delivery_token_ptr tok);
     /**
-     * @brief operationFailed is emitted when an action fails
+     * @brief onOperationFailed is emitted when an action fails
      * @param tok See mqtt::token
      */
-    void operationFailed(const mqtt::token& tok);
+    void onOperationFailed(const mqtt::token& tok);
     /**
-     * @brief operationSucceeded is emitted when an action has completed
+     * @brief onOperationSucceeded is emitted when an action has completed
      * successfully
      * @param tok See mqtt::token
      */
-    void operationSucceeded(const mqtt::token& tok);
+    void onOperationSucceeded(const mqtt::token& tok);
 
 private:
     mqtt::async_client_ptr client;


### PR DESCRIPTION
I had some troubles naming things and I recalled how it is done in QML.
QML can generate signals and by default it prepends "on" to give the
programmer heads-up.