### PR TITLE
Preview message history

### DIFF
--- a/src/explorerpage.cpp
+++ b/src/explorerpage.cpp
@@ -4,18 +4,71 @@
 #include "explorerpage.h"
 #include "ui_explorerpage.h"
 
-ExplorerPage::ExplorerPage(QWidget *parent) :
+void MessageTreeView::currentChanged(const QModelIndex &current, const QModelIndex &previous)
+{
+    emit this->onCurrentChanged(current);
+}
+
+ExplorerPage::ExplorerPage(QWidget *parent, int cap) :
     QWidget(parent),
-    ui(new Ui::ExplorerPage)
+    ui(new Ui::ExplorerPage),
+    message_capacity(cap)
 {
     ui->setupUi(this);
 
     ui->topicsTree->setModel(&this->topics_tree_model);
+
+    connect(ui->messageHistoryList, &QListWidget::currentItemChanged, this, &ExplorerPage::changeSelectedMessage);
+    connect(ui->topicsTree, &MessageTreeView::onCurrentChanged, this, &ExplorerPage::changeSelectedTopic);
 }
 
 ExplorerPage::~ExplorerPage()
 {
     delete ui;
+}
+
+void ExplorerPage::setMessageCap(int cap)
+{
+    this->message_capacity = cap;
+}
+
+void ExplorerPage::changeSelectedMessage(QListWidgetItem *current, QListWidgetItem *previous)
+{
+    auto curr_row = this->ui->messageHistoryList->row(current);
+    auto prev_row = this->ui->messageHistoryList->row(previous);
+
+    if (curr_row == prev_row) {
+        return;
+    }
+
+    if (curr_row == 1 && prev_row == 0 && this->ui->messageHistoryList->count() >= this->message_capacity) {
+        return;
+    }
+
+    emit this->onChangeSelectedMessage(curr_row);
+}
+
+void ExplorerPage::changeSelectedTopic(const QModelIndex &current)
+{
+    QString topic = "";
+
+    // Assemble the topic name
+    auto item = this->topics_tree_model.itemFromIndex(current);
+    for (; item != nullptr; item = item->parent()) {
+        topic.prepend(item->text());
+        if (item->parent() != 0) {
+            topic.prepend("/");
+        }
+    }
+
+    // The root is always the name of the server. It is not part of the topic name.
+    topic = topic.mid(topic.indexOf("/") + 1);
+
+    this->ui->topicNameLabel->setText(topic);
+    this->current_topic = topic;
+
+    this->ui->messageHistoryList->setCurrentRow(-1);
+    emit onChangeSelectedTopic(topic);
 }
 
 void ExplorerPage::initConnection(const QString server_name)
@@ -31,6 +84,28 @@ void ExplorerPage::receiveNewMessages(const QHash<QString, QList<QString>> new_m
         auto topic = i.key();
         this->addTopic(topic, false);
     }
+
+    // Don't touch the message history list if no relevant new messages arrived
+    if (!new_msgs.contains(this->current_topic)) {
+        return;
+    }
+
+    this->ui->messageHistoryList->addItems(new_msgs[this->current_topic]);
+    // Respect the set message capacity
+    for (int i = this->ui->messageHistoryList->count(); i > this->message_capacity; i--) {
+        delete this->ui->messageHistoryList->takeItem(0);
+    }
+}
+
+void ExplorerPage::setMessage(const QString msg)
+{
+    this->ui->messagePreview->setText(msg);
+}
+
+void ExplorerPage::setTopic(const QList<QString> topic_msgs)
+{
+    this->ui->messageHistoryList->clear();
+    this->ui->messageHistoryList->addItems(topic_msgs);
 }
 
 void ExplorerPage::addTopic(const QString topic, const bool root)

--- a/src/explorerpage.h
+++ b/src/explorerpage.h
@@ -1,8 +1,12 @@
 #ifndef EXPLORERPAGE_H
 #define EXPLORERPAGE_H
 
+#include <QList>
+#include <QListWidgetItem>
 #include <QWidget>
 #include <QStandardItemModel>
+#include <QString>
+#include <QTreeView>
 
 #include "mqtt/message.h"
 
@@ -10,21 +14,49 @@ namespace Ui {
 class ExplorerPage;
 }
 
+class MessageTreeView : public QTreeView
+{
+    Q_OBJECT
+
+public:
+    explicit MessageTreeView(QWidget *parent = nullptr) : QTreeView(parent) {};
+
+signals:
+    void onCurrentChanged(const QModelIndex &current);
+
+private:
+    virtual void currentChanged(const QModelIndex &current, const QModelIndex &previous);
+};
+
 class ExplorerPage : public QWidget
 {
     Q_OBJECT
 
 public:
-    explicit ExplorerPage(QWidget *parent = nullptr);
+    explicit ExplorerPage(QWidget *parent = nullptr, int cap = 50);
     ~ExplorerPage();
 
+    QString current_topic; //<currently selected topic
+
+    void setMessageCap(int cap);
+
+signals:
+    void onChangeSelectedMessage(const int currentRow);
+    void onChangeSelectedTopic(QString topic);
+
 public slots:
+    void changeSelectedMessage(QListWidgetItem *current, QListWidgetItem *previous);
+    void changeSelectedTopic(const QModelIndex &current);
     void initConnection(const QString server_name);
     void receiveNewMessages(const QHash<QString, QList<QString>> new_msgs);
+    void setMessage(QString msg);
+    void setTopic(QList<QString>);
 
 private:
     Ui::ExplorerPage *ui;
     QStandardItemModel topics_tree_model;
+
+    int message_capacity;
 
     void addTopic(const QString topic, const bool root);
 };

--- a/src/explorerpage.ui
+++ b/src/explorerpage.ui
@@ -6,20 +6,20 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>945</width>
+    <width>889</width>
     <height>658</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
+  <layout class="QHBoxLayout" name="horizontalLayout">
    <item>
     <widget class="QSplitter" name="splitter">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
-     <widget class="QTreeView" name="topicsTree">
+     <widget class="MessageTreeView" name="topicsTree">
       <property name="uniformRowHeights">
        <bool>true</bool>
       </property>
@@ -33,18 +33,309 @@
        <number>25</number>
       </attribute>
      </widget>
-     <widget class="QFrame" name="frame">
-      <property name="frameShape">
-       <enum>QFrame::StyledPanel</enum>
+     <widget class="QScrollArea" name="scrollArea">
+      <property name="widgetResizable">
+       <bool>true</bool>
       </property>
-      <property name="frameShadow">
-       <enum>QFrame::Raised</enum>
-      </property>
+      <widget class="QWidget" name="scrollAreaWidgetContents">
+       <property name="geometry">
+        <rect>
+         <x>0</x>
+         <y>0</y>
+         <width>477</width>
+         <height>638</height>
+        </rect>
+       </property>
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <layout class="QVBoxLayout" name="verticalLayout_2">
+        <item>
+         <layout class="QVBoxLayout" name="sectionSelectedTopic">
+          <item>
+           <widget class="QLabel" name="sectionTopicLabel">
+            <property name="text">
+             <string>&lt;b&gt;Selected topic:&lt;b&gt;</string>
+            </property>
+            <property name="textFormat">
+             <enum>Qt::AutoText</enum>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_4">
+            <item>
+             <widget class="QLabel" name="topicNameLabel">
+              <property name="text">
+               <string/>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <widget class="Line" name="separator_1">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QSplitter" name="splitter_2">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="opaqueResize">
+           <bool>false</bool>
+          </property>
+          <widget class="QTabWidget" name="tabReceiveSend">
+           <property name="tabPosition">
+            <enum>QTabWidget::North</enum>
+           </property>
+           <property name="currentIndex">
+            <number>0</number>
+           </property>
+           <property name="documentMode">
+            <bool>true</bool>
+           </property>
+           <widget class="QWidget" name="tab">
+            <attribute name="title">
+             <string>Receive</string>
+            </attribute>
+            <layout class="QVBoxLayout" name="verticalLayout_4">
+             <item>
+              <layout class="QVBoxLayout" name="verticalLayout">
+               <item>
+                <widget class="QLabel" name="sectionReceivedMessagesLabel">
+                 <property name="text">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Selected message:&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QTextEdit" name="messagePreview">
+                 <property name="maximumSize">
+                  <size>
+                   <width>16777215</width>
+                   <height>16777215</height>
+                  </size>
+                 </property>
+                 <property name="autoFormatting">
+                  <set>QTextEdit::AutoAll</set>
+                 </property>
+                 <property name="tabChangesFocus">
+                  <bool>false</bool>
+                 </property>
+                 <property name="documentTitle">
+                  <string/>
+                 </property>
+                 <property name="readOnly">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </item>
+            </layout>
+           </widget>
+           <widget class="QWidget" name="tab_2">
+            <attribute name="title">
+             <string>Send</string>
+            </attribute>
+            <layout class="QVBoxLayout" name="verticalLayout_5">
+             <item>
+              <widget class="QLabel" name="sectionSendMessageLabel">
+               <property name="text">
+                <string>&lt;b&gt;Send message:&lt;/b&gt;</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QRadioButton" name="radioButtonPlainText">
+               <property name="text">
+                <string>Plain text</string>
+               </property>
+               <property name="checked">
+                <bool>true</bool>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <layout class="QHBoxLayout" name="horizontalLayout_2">
+               <item>
+                <widget class="QRadioButton" name="radioButton_file">
+                 <property name="text">
+                  <string>File</string>
+                 </property>
+                 <property name="checked">
+                  <bool>false</bool>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QLineEdit" name="fileNameLineEdit">
+                 <property name="enabled">
+                  <bool>false</bool>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QPushButton" name="fileChooseButton">
+                 <property name="enabled">
+                  <bool>false</bool>
+                 </property>
+                 <property name="text">
+                  <string>Browse...</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </item>
+             <item>
+              <widget class="QTextEdit" name="messageTextEdit">
+               <property name="enabled">
+                <bool>true</bool>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QPushButton" name="sendButton">
+               <property name="text">
+                <string>Send</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </widget>
+          <widget class="QWidget" name="layoutWidget">
+           <layout class="QVBoxLayout" name="verticalLayout_3">
+            <item>
+             <widget class="QLabel" name="sectionMessageHistoryLabel">
+              <property name="text">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Message history:&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QScrollArea" name="messageHistoryScroller">
+              <property name="frameShape">
+               <enum>QFrame::NoFrame</enum>
+              </property>
+              <property name="frameShadow">
+               <enum>QFrame::Plain</enum>
+              </property>
+              <property name="widgetResizable">
+               <bool>true</bool>
+              </property>
+              <widget class="QWidget" name="scrollAreaWidgetContents_2">
+               <property name="geometry">
+                <rect>
+                 <x>0</x>
+                 <y>0</y>
+                 <width>457</width>
+                 <height>202</height>
+                </rect>
+               </property>
+               <layout class="QVBoxLayout" name="verticalLayout_7">
+                <item>
+                 <widget class="QListWidget" name="messageHistoryList">
+                  <property name="autoScroll">
+                   <bool>true</bool>
+                  </property>
+                  <property name="alternatingRowColors">
+                   <bool>true</bool>
+                  </property>
+                  <property name="isWrapping" stdset="0">
+                   <bool>false</bool>
+                  </property>
+                  <property name="resizeMode">
+                   <enum>QListView::Adjust</enum>
+                  </property>
+                  <property name="wordWrap">
+                   <bool>true</bool>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </widget>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </widget>
+        </item>
+       </layout>
+      </widget>
      </widget>
     </widget>
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>MessageTreeView</class>
+   <extends>QTreeView</extends>
+   <header>src/explorerpage.h</header>
+  </customwidget>
+ </customwidgets>
+ <tabstops>
+  <tabstop>topicsTree</tabstop>
+ </tabstops>
  <resources/>
- <connections/>
+ <connections>
+  <connection>
+   <sender>radioButtonPlainText</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>messageTextEdit</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>453</x>
+     <y>156</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>461</x>
+     <y>270</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>radioButton_file</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>fileNameLineEdit</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>420</x>
+     <y>194</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>526</x>
+     <y>191</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>radioButton_file</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>fileChooseButton</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>442</x>
+     <y>193</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>823</x>
+     <y>193</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
 </ui>

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -15,6 +15,8 @@ MainWindow::MainWindow(QWidget *parent) :
 {
     this->ui->setupUi(this);
 
+    this->explorer->setMessageCap(msg_store->getMessageCap());
+
     this->mqtt_manager->moveToThread(&worker_thread);
     this->worker_thread.start();
 
@@ -80,6 +82,9 @@ void MainWindow::setupActions()
     connect(this->ui->actionConnect, &QAction::triggered, mqtt_manager, &MQTTManager::connect);
     connect(this->ui->actionNewConnection, &QAction::triggered, this, &MainWindow::OpenConnectionWindow);
 
+    connect(this->explorer, &ExplorerPage::onChangeSelectedMessage, this, &MainWindow::explorerChangeSelectedMessage);
+    connect(this->explorer, &ExplorerPage::onChangeSelectedTopic, this, &MainWindow::explorerChangeSelectedTopic);
+
     // MQTT related signals
     connect(this->mqtt_manager, &MQTTManager::onConnected, this, &MainWindow::updateStatusBar);
     connect(this->mqtt_manager, &MQTTManager::onConnected, this, &MainWindow::clientConnected);
@@ -101,5 +106,22 @@ void MainWindow::updateStatusBar()
 void MainWindow::clientConnected()
 {
     auto server_name = this->mqtt_manager->getServerName();
+
     this->explorer->initConnection(server_name);
+}
+
+void MainWindow::explorerChangeSelectedMessage(const int currentRow)
+{
+    auto topic_messages = this->msg_store->getTopicMessages(this->explorer->current_topic);
+
+    if (currentRow >= 0 && currentRow < topic_messages.count()) {
+        this->explorer->setMessage(topic_messages[currentRow]);
+    }
+}
+
+void MainWindow::explorerChangeSelectedTopic(QString topic)
+{
+    auto topic_msgs = this->msg_store->getTopicMessages(topic);
+
+    this->explorer->setTopic(topic_msgs);
 }

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -58,6 +58,8 @@ private:
 
 private slots:
     void clientConnected();
+    void explorerChangeSelectedMessage(const int currentRow);
+    void explorerChangeSelectedTopic(QString topic);
 };
 
 #endif // MAINWINDOW_H

--- a/src/messagestore.cpp
+++ b/src/messagestore.cpp
@@ -13,7 +13,7 @@ MessageStore::MessageStore(QObject *parent) :
 
 void MessageStore::setMessageCap(int cap)
 {
-
+    this->message_capacity = cap;
 }
 
 int MessageStore::getMessageCap()

--- a/src/messagestore.cpp
+++ b/src/messagestore.cpp
@@ -43,13 +43,9 @@ void MessageStore::addMessage(const mqtt::const_message_ptr msg)
     auto qtopic = QString::fromStdString(msg->get_topic());
     QList<QString> msg_list = this->new_messages[qtopic];
 
-    if (msg_list.length() >= this->message_capacity) {
-        msg_list.pop_front();
-    }
-
     msg_list.append(QString::fromStdString(msg->get_payload_str()));
 
-    this->new_messages[qtopic] = msg_list;
+    this->new_messages.insert(qtopic, msg_list);
 }
 
 void MessageStore::handleTick()

--- a/src/messagestore.cpp
+++ b/src/messagestore.cpp
@@ -54,6 +54,21 @@ void MessageStore::handleTick()
         return;
     }
 
-    emit this->newMessages(this->new_messages);
+    auto new_messages = this->new_messages;
+
     this->new_messages.clear();
+    for (auto i = new_messages.begin(); i != new_messages.end(); i++) {
+        auto section = this->messages.take(i.key());
+
+        section.append(i.value());
+
+        this->messages.insert(i.key(), section);
+    }
+
+    for (auto i = this->messages.begin(); i != this->messages.end(); i++) {
+        this->messages.insert(i.key(),
+            i.value().mid(i.value().count() - this->message_capacity, -1));
+    }
+
+    emit this->newMessages(new_messages);
 }

--- a/src/messagestore.cpp
+++ b/src/messagestore.cpp
@@ -26,14 +26,13 @@ const QHash<QString, QList<QString>> MessageStore::getAllMessages()
     return this->messages;
 }
 
-const QList<QString> MessageStore::getTopicMessages(const std::string topic)
+const QList<QString> MessageStore::getTopicMessages(const QString topic)
 {
-    auto qtopic = QString::fromStdString(topic);
-    if (!this->messages.contains(qtopic)) {
+    if (!this->messages.contains(topic)) {
         return QList<QString>();
     }
 
-    return this->messages[qtopic];
+    return this->messages[topic];
 }
 
 void MessageStore::addMessage(const mqtt::const_message_ptr msg)

--- a/src/messagestore.h
+++ b/src/messagestore.h
@@ -19,7 +19,7 @@ public:
 
     const QHash<QString, QList<QString>> getAllMessages();
     const QHash<QString, QList<QString>> getNewMessages();
-    const QList<QString> getTopicMessages(const mqtt::string topic);
+    const QList<QString> getTopicMessages(const QString topic);
 
 signals:
     void newMessages(const QHash<QString, QList<QString>>);


### PR DESCRIPTION
With this the right part of the Explorer widget finally gets some
functionality. When a topic is clicked, the message list is populated
with all messages related to the said topic. When one of the items in
the list is further clicked on, the message preview is populated with
the content of the message.

Still requires having documentation added.