### PR TITLE
explorerpage: Reverse message history list, truncate previews

### DIFF
--- a/src/explorerpage.h
+++ b/src/explorerpage.h
@@ -58,6 +58,15 @@ private:
 
     int message_capacity;
 
+    /**
+     * @brief addMessages() adds strings to the message history list
+     * @details If a message is longer than 26 characters, it is truncated and
+     * three dots at the end are added to signify the truncation. Every message
+     * is parsed into a pixmap to try to see if there is an image (JPG/PNG).
+     * This does not function properly, yet. The message capacity is respected
+     * by deleting the oldest messages in the list.
+     */
+    void addMessages(QList<QString> msgs);
     void addTopic(const QString topic, const bool root);
 };
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -121,8 +121,11 @@ void MainWindow::explorerChangeSelectedMessage(const int currentRow)
 {
     auto topic_messages = this->msg_store->getTopicMessages(this->explorer->current_topic);
 
-    if (currentRow >= 0 && currentRow < topic_messages.count()) {
-        this->explorer->setMessage(topic_messages[currentRow]);
+    // Explorer lists messages in reverse order than they are represented internally.
+    // Translate the index to the internal version.
+    int index = topic_messages.count()-currentRow-1;
+    if (index >= 0 && index < topic_messages.count()) {
+        this->explorer->setMessage(topic_messages[index]);
     }
 }
 


### PR DESCRIPTION
It seemed more natural for the message history list to grow down instead
of growing up. This required putting in place a hack that prevents
having to rething the way messages are stored.

Messages are now truncated to 26 characters as per instructions. To view
the whole message, click on it in the list and the preview window will
be populated. In the future and additional way of handling e.g. images
will have to be added.

Foundation for recognizing images in payloads has been laid but it does
not function, yet. I spent significant time trying to make it work but
it is no longer worth it. I might return to it later on.