### PR TITLE
mainWindow: Unify toolbars and make it persistent

### DIFF
--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -59,8 +59,20 @@
    <property name="windowTitle">
     <string>toolBar</string>
    </property>
+   <property name="movable">
+    <bool>true</bool>
+   </property>
+   <property name="iconSize">
+    <size>
+     <width>32</width>
+     <height>32</height>
+    </size>
+   </property>
    <property name="toolButtonStyle">
-    <enum>Qt::ToolButtonTextBesideIcon</enum>
+    <enum>Qt::ToolButtonIconOnly</enum>
+   </property>
+   <property name="floatable">
+    <bool>false</bool>
    </property>
    <attribute name="toolBarArea">
     <enum>TopToolBarArea</enum>
@@ -68,35 +80,10 @@
    <attribute name="toolBarBreak">
     <bool>false</bool>
    </attribute>
-   <addaction name="actionDashboard"/>
-   <addaction name="separator"/>
-   <addaction name="actionExplorer"/>
-  </widget>
-  <widget class="QToolBar" name="toolBar_2">
-   <property name="font">
-    <font>
-     <family>Arial Nova Light</family>
-    </font>
-   </property>
-   <property name="windowTitle">
-    <string>toolBar_2</string>
-   </property>
-   <property name="iconSize">
-    <size>
-     <width>26</width>
-     <height>26</height>
-    </size>
-   </property>
-   <property name="toolButtonStyle">
-    <enum>Qt::ToolButtonTextUnderIcon</enum>
-   </property>
-   <attribute name="toolBarArea">
-    <enum>LeftToolBarArea</enum>
-   </attribute>
-   <attribute name="toolBarBreak">
-    <bool>false</bool>
-   </attribute>
    <addaction name="actionConnect"/>
+   <addaction name="separator"/>
+   <addaction name="actionDashboard"/>
+   <addaction name="actionExplorer"/>
    <addaction name="separator"/>
    <addaction name="actionActualState"/>
    <addaction name="actionHistory"/>
@@ -215,6 +202,24 @@
  </customwidgets>
  <resources>
   <include location="../resources.qrc"/>
+  <include location="../resources.qrc"/>
  </resources>
- <connections/>
+ <connections>
+  <connection>
+   <sender>toolBar</sender>
+   <signal>visibilityChanged(bool)</signal>
+   <receiver>toolBar</receiver>
+   <slot>show()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>340</x>
+     <y>57</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>408</x>
+     <y>59</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
 </ui>


### PR DESCRIPTION
Having two toolbars for the same thing is unnecessary.

A toolbar is a widget that can be hidden. Normally, a toolbar can be
brought back by: right clicking on another toolbar, right clicking on a
menu or having an action in another toolbar/menu. I do not want to deal
with this, so I connected the changeVisibility method to show() which
effectively makes it impossible to hide the toolbar.

The new view:
![image](https://user-images.githubusercontent.com/17991284/117550421-950d3b80-b040-11eb-991e-11820d490d3f.png)