### PR TITLE
mainwindow: Explicitely set Dashboard as the primary view

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -31,6 +31,9 @@ MainWindow::MainWindow(QWidget *parent) :
 
     MainWindow::setupStatusBar();
     MainWindow::setupActions();
+
+    // Make sure the right page and actions in toolbar are shown
+    this->setDashboardPage();
 }
 
 MainWindow::~MainWindow()


### PR DESCRIPTION
Calling the method is necessary for ensuring the correct actions are
shown in the toolbar.