### PR TITLE
mqttmanager: Adjust connection options and default subscription

### DIFF
--- a/src/messagestore.cpp
+++ b/src/messagestore.cpp
@@ -8,7 +8,7 @@ MessageStore::MessageStore(QObject *parent) :
     new_messages(QHash<QString, QList<QString>>())
 {
     connect(this->ticker, &QTimer::timeout, this, &MessageStore::handleTick);
-    this->ticker->start(200);
+    this->ticker->start(400);
 }
 
 void MessageStore::setMessageCap(int cap)


### PR DESCRIPTION
It makes more sense to start with a clean plate every time a client
connects to the server. Also, it is good to let the library handle
automatic reconnection in case the app loses it.

Due to the design of the app (Explorer for watching every topic known to
the broker and Dashboard for nice view of specific topics) it makes more
sense to subscribe to _all_ topics.

Also, no longer close the app when failing to connect to a server.