### PR TITLE
Change the way messages are stored & discern sent/received messages in Explorer

### DIFF
--- a/src/explorerpage.cpp
+++ b/src/explorerpage.cpp
@@ -1,3 +1,5 @@
+#include <QBrush>
+#include <QColor>
 #include <QFileDialog>
 #include <QHash>
 #include <QPixmap>
@@ -153,6 +155,7 @@ void ExplorerPage::addMessages(QList<Message*> msgs)
     for (auto it = msgs.begin(); it != msgs.end(); it++) {
         std::string msg = (*it)->getMessage();
         QByteArray data(msg.c_str(), msg.length());
+        QListWidgetItem *new_item = new QListWidgetItem;
         QPixmap pixmap;
 
         if (pixmap.loadFromData(data, "JPG") || pixmap.loadFromData(data, "PNG")) {
@@ -168,7 +171,17 @@ void ExplorerPage::addMessages(QList<Message*> msgs)
             }
         }
 
-        this->ui->messageHistoryList->insertItem(0, QString::fromStdString(msg));
+        new_item->setText(QString::fromStdString(msg));
+        // Based on message type set background color. I took some colors that
+        // looked nice in Krita.
+        if ((*it)->msg_type == MessageType::RECEIVED) {
+            new_item->setBackground(QBrush(QColor(184, 244, 245)));
+        } else {
+            new_item->setBackground(QBrush(QColor(255, 125, 125)));
+        }
+
+        this->ui->messageHistoryList->insertItem(0, new_item);
+
         // Respect the set message capacity
         for (int i = this->ui->messageHistoryList->count(); i > this->message_capacity; i--) {
             delete this->ui->messageHistoryList->takeItem(i-1);

--- a/src/explorerpage.h
+++ b/src/explorerpage.h
@@ -8,6 +8,7 @@
 #include <QString>
 #include <QTreeView>
 
+#include "messagestore.h"
 #include "mqtt/message.h"
 
 namespace Ui {
@@ -62,7 +63,7 @@ public slots:
     void changeSelectedMessage(QListWidgetItem *current, QListWidgetItem *previous);
     void changeSelectedTopic(const QModelIndex &current);
     void initConnection(const QString server_name);
-    void receiveNewMessages(const QHash<QString, QList<QString>> new_msgs);
+    void receiveNewMessages(const QHash<QString, QList<Message*>> new_msgs);
     /**
      * @brief selectFile() spawns a QFileDialog, gets the selected file name
      * and sets it to relevant QLineEdit
@@ -76,8 +77,8 @@ public slots:
      * messages to a different subtopic.
      */
     void sendMessage();
-    void setMessage(QString msg);
-    void setTopic(QList<QString>);
+    void setMessage(Message *msg);
+    void setTopic(QList<Message*>);
 
 private:
     Ui::ExplorerPage *ui;
@@ -90,10 +91,10 @@ private:
      * @details If a message is longer than 26 characters, it is truncated and
      * three dots at the end are added to signify the truncation. Every message
      * is parsed into a pixmap to try to see if there is an image (JPG/PNG).
-     * This does not function properly, yet. The message capacity is respected
-     * by deleting the oldest messages in the list.
+     * The message capacity is respected by deleting the oldest messages in the
+     * list.
      */
-    void addMessages(QList<QString> msgs);
+    void addMessages(QList<Message*> msgs);
     void addTopic(const QString topic, const bool root);
 };
 


### PR DESCRIPTION
Filtering of received messages based on sent messages isn't very reliable. Be careful while demoing. Is possibly caused by the fact that MQTT client lives in a thread and the message storage does not.

Recognizing of binary payloads (e.g., images) is not functional, yet.